### PR TITLE
move 'region' getter from 'config' to 'credentials' section

### DIFF
--- a/shared-config.lisp
+++ b/shared-config.lisp
@@ -58,7 +58,11 @@
                  :secret-access-key secret-access-key
                  :session-token (aget section "aws_session_token")
                  :provider-name (format nil "shared-config: ~A"
-                                        (shared-config-config-path shared-config)))))))
+                                        (shared-config-config-path shared-config))))))
+
+      (let ((region (aget section "region")))
+        (when region
+          (setf (shared-config-region shared-config) region))))
 
     (let ((section (with-slots (config-path profile) shared-config
                      (when (and config-path
@@ -83,10 +87,6 @@
                                          :credential-source credential-source
                                          :external-id (aget section "external_id")
                                          :serial-number (aget section "mfa_serial")
-                                         :role-session-name (aget section "role_session_name")))))
-
-      (let ((region (aget section "region")))
-        (when region
-          (setf (shared-config-region shared-config) region))))
+                                         :role-session-name (aget section "role_session_name"))))))
 
     shared-config))


### PR DESCRIPTION
Fixes bug where the `region` was being fetched from the wrong section (should be in the `credentials` file, not the `config` file)